### PR TITLE
Add extract and minify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ configure :build do
   activate :critical, :binary => '/usr/local/bin/critical'  # binary defaults to 'critical'
 
 ```
+#### Options
+```
+:binary  => 'critical'  # The critical binary to use
+:extract => false  # Extract inlined styles from referenced stylesheets
+:minify  => false  # Minify critical-path CSS when inlining
+```
+

--- a/lib/middleman-critical/extension.rb
+++ b/lib/middleman-critical/extension.rb
@@ -5,6 +5,8 @@ module Middleman
   class CriticalExtension < Extension
 
     option :binary, 'critical', 'The critical binary to use'
+    option :extract, false, 'Extract inlined styles from referenced stylesheets'
+    option :minify, false, 'Minify critical-path CSS when inlining'
 
     def initialize(app, options_hash={}, &block)
       super
@@ -26,7 +28,7 @@ module Middleman
       Dir.glob(htmlDir) do |file|
         assetPath = rootPath + File::SEPARATOR + file
         file.slice! buildDir + File::SEPARATOR
-        %x(#{options.binary} #{assetPath} --base #{buildDir} --htmlTarget #{file} --extract --inline)
+        %x(#{options.binary} #{assetPath} --base #{buildDir} --htmlTarget #{file} --inline #{'--extract' if options.extract} #{'--minify' if options.minify})
       end
 
     end


### PR DESCRIPTION
Adding the `params` option allows me to remove `--extract` and add `--minify` without breaking backwards compatibility. Please tell me if you would rather have booleans to activate minification.